### PR TITLE
Fix security vulnerabilities (aiohttp, starlette, pytest, flask, black)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 flask = "==2.3.*"
 
 [dev-packages]
-black = "*"
+black = ">=26.3.1"
 
 [requires]
 python_version = "3.11"

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,8 +1,8 @@
-flask==2.2.*
+flask==3.1.*
 fastapi==0.89.*
-aiohttp==3.8.*
+aiohttp==3.13.*
 redis==4.4.*
-pytest==7.2.*
+pytest==9.0.*
 httpx==0.23.*
 pytest-mock==3.10.*
 fakeredis==2.5.*
@@ -10,4 +10,4 @@ pytest-asyncio==0.20.*
 uvicorn==0.20.*
 kubernetes==25.3.*
 fastapi==0.89.*
-starlette==0.25.*
+starlette==0.47.*

--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -1,5 +1,5 @@
-flask==2.2.*
+flask==3.1.*
 fastapi==0.89.*
 uvicorn==0.20.*
 kubernetes==25.3.*
-starlette==0.25.*
+starlette==0.47.*


### PR DESCRIPTION
## Summary
- **aiohttp** `3.8.*` → `3.13.*` — resolves 19 CVEs including HIGH severity SSRF, header injection, zip bomb, HTTP request smuggling, and multiple DoS vectors
- **starlette** `0.25.*` → `0.47.*` — resolves 2 MEDIUM CVEs: DoS via large multipart form parsing
- **pytest** `7.2.*` → `9.0.*` — resolves MEDIUM CVE: vulnerable tmpdir handling
- **flask** `2.2.*` → `3.1.*` — resolves 4 LOW CVEs: missing `Vary: Cookie` header on session access
- **black** pinned to `>=26.3.1` — resolves HIGH CVE: arbitrary file writes from unsanitised cache file names

## Test plan
- [ ] Verify Docker builds complete with updated dependency versions
- [ ] Run existing test suite against updated dependencies
- [ ] Confirm Dependabot security alerts are resolved after merge