### PR TITLE
Fix starlette HIGH CVE: bump to 0.49.* (Range header DoS)

### DIFF
--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -10,4 +10,4 @@ pytest-asyncio==0.20.*
 uvicorn==0.20.*
 kubernetes==25.3.*
 fastapi==0.89.*
-starlette==0.47.*
+starlette==0.49.*

--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -2,4 +2,4 @@ flask==3.1.*
 fastapi==0.89.*
 uvicorn==0.20.*
 kubernetes==25.3.*
-starlette==0.47.*
+starlette==0.49.*


### PR DESCRIPTION
## Summary
- **starlette** `0.47.*` → `0.49.*` — resolves HIGH CVE: O(n²) DoS via Range header merging in `FileResponse`, fixed in 0.49.1

The previous security PR bumped starlette to 0.47.* which resolved the multipart DoS CVEs but missed this Range header vulnerability which requires 0.49.1+.