### PR TITLE
Update deprecated GKE workflow actions (v0 → v2)

### DIFF
--- a/.github/workflows/google-gke-deploy.yml
+++ b/.github/workflows/google-gke-deploy.yml
@@ -40,12 +40,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Configure Workload Identity Federation and generate an access token.
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v0'
+      uses: 'google-github-actions/auth@v2'
       with:
         token_format: 'access_token'
         workload_identity_provider: 'projects/564303631352/locations/global/workloadIdentityPools/microlink-github-pool/providers/microlink-github-provider'
@@ -56,7 +56,7 @@ jobs:
         echo ${{steps.auth.outputs.access_token}} | docker login -u oauth2accesstoken --password-stdin https://$GAR_LOCATION-docker.pkg.dev
     # Get the GKE credentials so we can deploy to the cluster
     - name: Set up GKE credentials
-      uses: google-github-actions/get-gke-credentials@v0
+      uses: google-github-actions/get-gke-credentials@v2
       with:
         cluster_name: ${{ env.GKE_CLUSTER }}
         location: ${{ env.GKE_ZONE }}


### PR DESCRIPTION
## Summary
- `actions/checkout` v3 → v4
- `google-github-actions/auth` v0 → v2 (v0 is end-of-life, no longer receives security patches)
- `google-github-actions/get-gke-credentials` v0 → v2 (was blocking deployments with deprecation error)